### PR TITLE
feat(#26): Change icon for blade templates (file->filetype)

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -179,13 +179,12 @@
     "dockerfile": "file_type_dockerfile",
     "docker-compose.yml": "file_type_dockercompose",
     "yarn.lock": "file_type_yarn",
-    ".htaccess": "file_type_htaccess",
-    "blade.php": "file_type_blade"
+    ".htaccess": "file_type_htaccess"
   },
   "fileExtensions": {
     "css": "file_type_css",
     "js": "file_type_javascript",
-    "mjs": "file_type_javascript",  
+    "mjs": "file_type_javascript",
     "txt": "file_type_text",
     "json": "file_type_json",
     "ts": "file_type_typescript",
@@ -256,6 +255,7 @@
     "rs": "file_type_rust",
     "jl": "file_type_julia",
     "twig": "file_type_twig",
-    "html.twig": "file_type_twig"
+    "html.twig": "file_type_twig",
+    "blade.php": "file_type_blade"
   }
 }


### PR DESCRIPTION
Changes the icons for blade templates. Those are not allways the exact phrase `blade.php` but rather files with an extension of `blade.php` i.e. a file like this: `foo-bar-baz.blade.php`.